### PR TITLE
add explicit versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ free or for profit. These rights, none can deny!
 
 
 
-Latest Poetic License
-=====================
+Poetic License 2.0
+------------------
 
 © <YEAR> <NAME>
 
@@ -35,8 +35,8 @@ On this notice, these rights rely.
 
 
 
-Original Poetic License
-=======================
+Poetic License 1.0
+------------------
 
 (c) 2005 Alexander E Genaud
 


### PR DESCRIPTION
This allows proper reference to specific versions, since "latest" is a relative term that can be outdated and cause ambiguity if a new version is eventually produced. For example, refer to the "New"/"Revised" BSD license (3-clause), which was succeeded by the "Simplified" BSD license (2-clause).
